### PR TITLE
add initial implementation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# Editorconfig file for cross-platform configuration of editors.
+root=true
+
+[*.py]
+max_line_length=99
+
+[*.rst]
+indent_style=space
+indent_size=4
+
+[*.html]
+indent_style=space
+indent_size=2
+
+[*.{yml,yaml}]
+indent_style=space
+indent_size=2
+
+[*.ini]
+indent_style=space
+indent_size=4

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length=99

--- a/README.md
+++ b/README.md
@@ -1,0 +1,79 @@
+# IAR migration scripts
+
+This repository contains scripts to migrate the existing IAR spreadsheet
+semi-automatically to the new backend.
+
+## Installation
+
+```console
+$ pip install -r requirements.txt
+```
+
+## Migration
+
+The ``migrate.py`` script takes a CSV export from the spreadsheet and writes a
+series of YAML documents to an output. The documents correspond to migrated
+assets and a migration report.
+
+Run via:
+
+```console
+$ ./migrate.py --output=assets.yaml input.csv
+```
+
+This must be run on a machine within the CUDN since it uses Lookup to attempt to
+reconcile the free-form "department" field with a Lookup instid. Any fields
+which cannot be reconciled are left blank.
+
+Each asset migration document has the following form:
+
+```yaml
+type: asset
+asset:
+  id: string # Generated UUID
+  department: string
+  name: string
+  personal_data: boolean
+  private: boolean
+  purpose: string
+  risk_type: list of strings
+errors: # optional can have zero or more of the following errors
+- code: E001
+  message: Department could not be resolved
+original:
+  # extracted original fields from the CSV. Preserved to aid manual
+  # reconciliation
+```
+
+The migration report document has the following form:
+
+```yaml
+type: report
+original_dept_mapping:
+  # List of instid/original mappings giving the orignal input in the spreadsheet
+  # and the inferred lookup instid. Mappings which could not be inferred have
+  # an instid of null.
+- original: Biochemistry
+  instid: BIOCH
+  # ...
+```
+
+## Uploading
+
+Once the asset documents are prepared, they may be uploaded *en mass* via the
+``upload.py`` script:
+
+```console
+$ ./upload.py --output=upload-report.yaml assets.yaml
+```
+
+The upload script generates a file with one YAML document per upload of the
+following form:
+
+```yaml
+type: upload
+status_code: integer # HTTP status code of response
+source_id: string # id of asset from input assets file
+dest_id: string # on success, assigned if of asset from IAR backend
+error: object # on error, body of response from server
+```

--- a/migrate.py
+++ b/migrate.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python
+"""
+Migrate old IAR spreadsheet to new format
+
+Usage:
+    migrate.py (-h | --help)
+    migrate.py [--verbose] [--skip-rows=NUM] [--skip-cols=NUM] [--output=FILE] [<csv>]
+
+Options:
+
+    --verbose, -v           Increase output verbosity.
+
+    --output=FILE           Output YAML dump file. Use "-" for standard input [default: -]
+    <csv>                   Input CSV. Use "-" for standard output. [default: -]
+
+    --skip-rows=NUM         Number of rows to skip in input CSV. [default: 6]
+    --skip-cols=NUM         Number of initial columns to skip in input CSV. [default: 1]
+
+"""
+import csv
+import logging
+import sys
+import uuid
+
+import docopt
+import yaml
+import ucamlookup.ibisclient as ibisclient
+
+
+LOG = logging.getLogger()
+
+MIGRATION_NS = uuid.UUID('d04a3354-2935-4247-b7c7-f9c505bb8634')
+
+
+class Context:
+    def __init__(self, cli_opts):
+        self._ibis_conn = ibisclient.createConnection()
+        self._cached_insts = {}
+
+        self.cli_opts = cli_opts
+        self.departments = set()
+
+    def resolve_institution(self, inst_name):
+        if inst_name in self._cached_insts:
+            return self._cached_insts[inst_name]
+
+        # Hunt for institution
+        im = ibisclient.InstitutionMethods(self._ibis_conn)
+        self._cached_insts[inst_name] = None
+
+        # Look for foo, Department of foo and Faculty of foo from a simple entry of "foo". An exact
+        # match always wins. A single approximate match wins.
+        for prefix in ['', 'Department of ', 'Faculty of ']:
+            search = prefix + inst_name
+            matches = im.search(search, approxMatches=True)
+
+            # Look for exact matches
+            exact_matches = [inst for inst in matches if inst.name == search]
+
+            # An exact match succeeds
+            if len(exact_matches) == 1:
+                self._cached_insts[inst_name] = exact_matches[0].instid
+                break
+
+            # If there is not exactly one approximate match, give up
+            if len(matches) != 1:
+                continue
+
+            # Found one, done!
+            self._cached_insts[inst_name] = matches[0].instid
+            break
+
+        return self._cached_insts[inst_name]
+
+
+def main():
+    opts = docopt.docopt(__doc__)
+    logging.basicConfig(level=logging.INFO if opts['--verbose'] else logging.WARN)
+
+    context = Context(cli_opts=opts)
+
+    with open_from_opt(opts['<csv>']) as infile, open_from_opt(opts['--output'], 'w') as outfile:
+        in_reader = csv.reader(infile)
+        for _ in range(int(opts['--skip-rows'])):
+            next(in_reader)
+        yaml.dump_all(migrate_rows(in_reader, context), outfile, default_flow_style=False)
+
+
+def extract_row(row, context):
+    """Given a row from the CSV, extract the named fields we care about."""
+    # Skip any initial columns
+    row = row[int(context.cli_opts['--skip-cols']):]
+    return {
+        'faculty_dept_inst': row[1],
+        'name': row[8],
+        'purpose': row[9],
+        'application': row[10],
+        'owners': row[11],
+        'availability_impact': row[12],
+        'confidentiality_impact': row[13],
+        'integrity_impact': row[14],
+        'personal_data': row[15:20],
+        'animal': row[22],
+        'animal_s24': row[23],
+        'recipients': row[29],
+        'within_eea': row[32],
+        'where_stored': row[35],
+        'password_or_locked': row[36],
+        'encryption_or_doubled_locked': row[37],
+        'retention': row[38],
+        'backup': row[42],
+        'backup_off_site': row[46],
+        'backup_off_site_regime': row[48],
+        'backup_off_site_location': row[49],
+    }
+
+
+def to_bool(text):
+    """Heuristically map a free-form text to boolean or None if we cannot."""
+    text = text.lower()
+    if text == 'y' or text == 'yes':
+        return True
+
+    if text == 'n' or text == 'no':
+        return False
+
+    return None
+
+
+def migrate_rows(rows, context):
+    for index, row in enumerate(rows):
+        yield migrate_row(index, row, context)
+
+    yield {
+        'type': 'report',
+        'original_dept_mapping': [
+            {'original': dept, 'instid': context.resolve_institution(dept)}
+            for dept in sorted(list(context.departments))
+        ],
+    }
+
+
+def migrate_row(index, row, context):
+    """Migrate an individual spreadsheet row."""
+
+    # Extract original columns we care about
+    original = extract_row(row, context)
+    context.departments.add(original['faculty_dept_inst'])
+
+    asset_id = str(uuid.uuid5(
+        MIGRATION_NS, original['name'] if original['name'] != '' else str(index)))
+
+    risks = []
+    if original['availability_impact'] != '':
+        risks.append('operational')
+    if original['confidentiality_impact'] != '':
+        risks.append('reputational')
+    if original['integrity_impact'] != '':
+        risks.append('financial')
+
+    # Perform easy migration to initialise asset
+    asset = {
+        'id': asset_id,
+        'name': original['name'], 'purpose': original['purpose'],
+        'department': context.resolve_institution(original['faculty_dept_inst']),
+        'personal_data': any([to_bool(v) for v in original['personal_data']]),
+        'private': any([to_bool(v) for v in [original['animal'], original['animal_s24']]]),
+        'risk_type': risks,
+    }
+
+    errors = []
+    if asset['department'] is None:
+        errors.append({'code': 'E001', 'message': 'Department could not be resolved'})
+
+    return_val = {'type': 'asset', 'asset': asset, 'original': original}
+    if len(errors) > 0:
+        return_val['errors'] = errors
+
+    return return_val
+
+
+def open_from_opt(opt, mode='r'):
+    """Open a file given an option value."""
+    if opt is None or opt == '-':
+        return sys.stdout if 'w' in mode else sys.stdin
+    return open(opt, mode)
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+docopt
+pyyaml
+django-ucamlookup
+requests

--- a/upload.py
+++ b/upload.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+"""
+Put migrated assets to server.
+
+Usage:
+    upload.py (-h | --help)
+    upload.py [--verbose] [--token=TOKEN] [--output=FILE] <endpoint> <document>...
+
+Options:
+
+    --verbose, -v           Increase output verbosity.
+
+    --token=TOKEN           Bearer token to use for authoirisation.
+
+    --output=FILE           Output upload report.
+    <endpoint>              IAR endpoint.
+    <document>              YAML document(s) containing asset records.
+
+"""
+import logging
+import sys
+
+import docopt
+import yaml
+import requests
+
+
+LOG = logging.getLogger()
+
+
+def main():
+    opts = docopt.docopt(__doc__)
+    logging.basicConfig(level=logging.INFO if opts['--verbose'] else logging.WARN)
+
+    session = requests.Session()
+    if opts['--token']:
+        session.headers.update({'Authorization': 'Bearer ' + opts['--token']})
+
+    endpoint = opts['<endpoint>']
+
+    # Generator for loading all the input asset documents
+    def load_docs():
+        for docfile in opts['<document>']:
+            LOG.info('Loading %s...', docfile)
+            with open(docfile) as infile:
+                for doc in yaml.load_all(infile):
+                    if 'type' not in doc or doc['type'] != 'asset':
+                        continue
+                    yield doc
+
+    with open_from_opt(opts['--output'], 'w') as outfile:
+        yaml.dump_all(
+            process_documents(session, endpoint, load_docs()), outfile, default_flow_style=False)
+
+
+def process_documents(session, endpoint, docs):
+    """Process an individual asset document."""
+    for doc in docs:
+        asset = doc['asset']
+        report = {'source_id': asset['id'], 'type': 'upload'}
+        r = session.post(endpoint, json=asset)
+        report['status_code'] = r.status_code
+
+        try:
+            r.raise_for_status()
+        except requests.HTTPError:
+            LOG.error('Saving asset failed: %s', r.json())
+            LOG.error('Original asset: %s', asset)
+            report['error'] = r.json()
+            yield report
+            continue
+
+        response = r.json()
+        LOG.info('Saved asset: %s as %s', asset['id'], response['id'])
+        report['dest_id'] = response['id']
+        yield report
+
+
+def open_from_opt(opt, mode='r'):
+    """Open a file given an option value."""
+    if opt is None or opt == '-':
+        return sys.stdout if 'w' in mode else sys.stdin
+    return open(opt, mode)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Add a basic migration implementation. The workflow is composed of two scripts:

* ``migrate.py`` which takes a CSV dump from the existing IAR, attempts to determined institutions/departments from lookup and writes asset resources to an output file as YAML documents.
* ``upload.py`` which takes asset resources as YAML documents and uploads them to the IAR.

See the included README for more information.